### PR TITLE
breaking: Rethought query api

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ In the simple case, there is simply just a `where` object. Let's see a sample:
 ```
 
 For more complex queries, this is not enough. We can instead create a nested
-query with more complicated statements using
-[CookieDB's extensive expressions](###Expressions). An example is:
+query with more complicated statements using CookieDB's extensive expressions
+(see below). An example is:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ In the simple case, there is simply just a `where` object. Let's see a sample:
 ```
 
 For more complex queries, this is not enough. We can instead create a nested
-query with more complicated statements using [CookieDB's extensive
-expressions](### Expressions). An example is:
+query with more complicated statements using
+[CookieDB's extensive expressions](###Expressions). An example is:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ const res = await req.text(); // "success"
 Inserts a document into `:table:`, will error out if table does not exist. If
 passed an array, it will bulk insert several documents.
 
+Note: Documents may not have a top-level key by the name of `key`. They also may
+not have any keys with a `.` in them.
+
 Ex:
 
 ```javascript
@@ -340,7 +343,7 @@ const req = await fetch("/select/users", {
     "Authorization": `Bearer ${token}`,
   },
   body: JSON.stringify({
-    where: "and(eq($name, 'Bryan'), gt($age, 10))"
+    where: "and(eq($name, 'Bryan'), gt($age, 10))",
     max_results: 1,
     show_keys: true,
     expand_keys: true,

--- a/README.md
+++ b/README.md
@@ -297,21 +297,65 @@ const res = await req.text(); // "success"
 Selects a number of documents from `:table:` given a query or queries, will
 error out if table does not exist.
 
-There are two ways of constructing a query, depending on how complicated it is.
-In the simple syntax, there is simply just a `query` object. Let's see a sample:
+In the simple case, there is simply just a `where` object. Let's see a sample:
 
-```javascript
+```json
 {
-  query: {
-    name: "eq($, 'Bryan')",
-    age: "gt($, 10)"
-  }
+  "where": "eq($name, 'Bryan')"
 }
 ```
 
+For more complex queries, this is not enough. We can instead create a nested
+query with more complicated statements using [CookieDB's extensive
+expressions](### Expressions). An example is:
+
+```json
+{
+  "where": "or(eq($age, 18), eq($nested.property, 'builder'))"
+}
+```
+
+This would return any document that has an `age` property equal to `18` or a
+`nested.property` equal to `'builder'`. The statement can be arbitrarily
+complex.
+
+In addition to this, there are more optional arguments that can be included to
+customize the query more. Here is an example:
+
+```jsonc
+{
+  "where": "and(eq($name, 'Bryan'), gt($age, 10))",
+  "max_results": 1, // limits the number of results to a certain value
+  "show_keys": true, // return the keys of documents along with them
+  "expand_keys": true // automatically join foreign keys with the objects they link to
+}
+```
+
+Ex:
+
+```javascript
+const req = await fetch("/select/users", {
+  method: "POST",
+  headers: {
+    "Authorization": `Bearer ${token}`,
+  },
+  body: JSON.stringify({
+    where: "and(eq($name, 'Bryan'), gt($age, 10))"
+    max_results: 1,
+    show_keys: true,
+    expand_keys: true,
+  }),
+});
+
+const res = await req.json(); // list of matching documents, ex: [{ name: "Bryan", description: "Just a cool guy", is_cool: true, age: 18, best_friend: null, nested: { property: "builder"}}]
+```
+
+### Expressions
+
 We see here that we can query parts of objects using some simple expressions.
 These can be arbitrarily nested and combined. As you may have guessed, the `$`
-represents the value at that specific key. There are quite a few operators:
+operator allows for us to express that the value is a property and not just a .
+There are quite a few operators:
 
 - `and`
   - Takes in any number of inputs and does logical and on them
@@ -488,60 +532,3 @@ represents the value at that specific key. There are quite a few operators:
   - ex: `eq(sqrt(4), 2)`
 
 \* May not work as described due to technicalities
-
-For more complex queries, this is not enough. We can instead create a list of
-query objects with a statement to explain how to combine them. An example is:
-
-```javascript
-{
-  queries: [
-    {
-      age: "eq($, 18)",
-    },
-    {
-      nested: {
-        property: "eq($, 'builder')",
-      }
-    }
-  ],
-  statement: "or($0, $1)"
-}
-```
-
-This would return any document that matches the first OR the second query. The
-statement can be arbitrarily complex. There are three optional arguments that
-can be included regardless of the type of query. Here is an example:
-
-```javascript
-{
-  query: {
-    name: "eq($, 'Bryan')",
-    age: "gt($, 10)"
-  },
-  max_results: 1, // limits the number of results to a certain value
-  show_keys: true, // return the keys of documents along with them
-  expand_keys: true // automatically join foreign keys with the objects they link to
-}
-```
-
-Ex:
-
-```javascript
-const req = await fetch("/select/users", {
-  method: "POST",
-  headers: {
-    "Authorization": `Bearer ${token}`,
-  },
-  body: JSON.stringify({
-    query: {
-      name: "eq($, 'Bryan')",
-      age: "gt($, 10)",
-    },
-    max_results: 1,
-    show_keys: true,
-    expand_keys: true,
-  }),
-});
-
-const res = await req.json(); // list of matching documents, ex: [{ name: "Bryan", description: "Just a cool guy", is_cool: true, age: 18, best_friend: null, nested: { property: "builder"}}]
-```

--- a/mod.ts
+++ b/mod.ts
@@ -13,7 +13,7 @@ import { get } from "./src/operations/get.ts";
 import { update } from "./src/operations/update.ts";
 import { drop } from "./src/operations/drop.ts";
 import { del } from "./src/operations/delete.ts";
-import { selectQueries, selectQuery } from "./src/operations/select.ts";
+import { selectQuery } from "./src/operations/select.ts";
 import { ensureTenant } from "./src/util/fileOperations.ts";
 
 interface Config {
@@ -106,34 +106,16 @@ export function start(directory: string) {
           const maxResults = body.max_results ?? 100;
           const showKeys = body.show_keys ?? false;
           const expandKeys = body.expand_keys ?? false;
-          if (body.query) {
-            const results = selectQuery(
-              directory,
-              tenant,
-              table,
-              body.query,
-              {
-                maxResults,
-                showKeys,
-                expandKeys,
-              },
-            );
-            return new Response(JSON.stringify(results), { status: 200 });
-          }
-          if (!body.queries || !body.statement) {
-            throw "No query or no queries and statement were provided";
-          }
 
-          const results = selectQueries(
+          const results = selectQuery(
             directory,
             tenant,
             table,
-            body.queries,
-            body.statement,
             {
               maxResults,
               showKeys,
               expandKeys,
+              where: body?.where ?? "",
             },
           );
           return new Response(JSON.stringify(results), { status: 200 });

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -436,9 +436,7 @@ Deno.test({
     let req = await fetch(`http://localhost:8777/select/table`, {
       ...basicFetchOptions,
       body: JSON.stringify({
-        query: {
-          name: "eq($, 'Yogi')",
-        },
+        where: "eq($name, 'Yogi')",
       }),
     });
 
@@ -452,9 +450,7 @@ Deno.test({
     req = await fetch(`http://localhost:8777/select/tableWithSchema`, {
       ...basicFetchOptions,
       body: JSON.stringify({
-        query: {
-          age: "gt($, 10)",
-        },
+        where: "gt($age, 10)",
       }),
     });
 
@@ -492,17 +488,7 @@ Deno.test({
     req = await fetch(`http://localhost:8777/select/tableWithSchema`, {
       ...basicFetchOptions,
       body: JSON.stringify({
-        queries: [
-          {
-            age: "eq($, 18)",
-          },
-          {
-            nested: {
-              property: "eq($, 'coder')",
-            },
-          },
-        ],
-        statement: "or($0, $1)",
+        where: "or(eq($age, 18), eq($nested.property, 'coder'))",
       }),
     });
 
@@ -511,17 +497,7 @@ Deno.test({
     req = await fetch(`http://localhost:8777/select/tableWithSchema`, {
       ...basicFetchOptions,
       body: JSON.stringify({
-        queries: [
-          {
-            age: "eq($, 18)",
-          },
-          {
-            nested: {
-              property: "eq($, 'coder')",
-            },
-          },
-        ],
-        statement: "or($0, $1)",
+        where: "or(eq($age, 18), eq($nested.property, 'coder'))",
         show_keys: true,
         expand_keys: true,
       }),
@@ -570,17 +546,7 @@ Deno.test({
     req = await fetch(`http://localhost:8777/select/tableWithSchema`, {
       ...basicFetchOptions,
       body: JSON.stringify({
-        queries: [
-          {
-            age: "eq($, 18)",
-          },
-          {
-            nested: {
-              property: "eq($, 'coder')",
-            },
-          },
-        ],
-        statement: "or($0, $1)",
+        where: "or(eq($age, 18), eq($nested.property, 'coder'))",
         max_results: 1,
       }),
     });

--- a/src/operations/select.ts
+++ b/src/operations/select.ts
@@ -1,42 +1,23 @@
 import { readChunk, readMeta } from "../util/fileOperations.ts";
 import { evaluateCondition, parseCondition } from "../util/condition.ts";
 import { recursivelyExpandDocument } from "../util/expandDocument.ts";
-import { Document, PossibleTypes } from "../util/types.ts";
+import { Document } from "../util/types.ts";
 
 interface Match {
   [key: string]: string | Match;
-}
-
-function documentMatches(document: Document, match: Match) {
-  for (const [key, m] of Object.entries(match)) {
-    if (!Object.hasOwn(document, key)) {
-      return false;
-    }
-
-    const val = document[key];
-
-    if (typeof m === "string") {
-      const parseTree = parseCondition(m, val as PossibleTypes);
-      if (!evaluateCondition(parseTree)) return false;
-    } else {
-      if (!documentMatches(val as Document, m)) return false;
-    }
-  }
-
-  return true;
 }
 
 interface QueryOptions {
   maxResults: number;
   showKeys: boolean;
   expandKeys: boolean;
+  where: string;
 }
 
 export function selectQuery(
   directory: string,
   tenant: string,
   table: string,
-  match: Match,
   opts: QueryOptions,
 ) {
   const meta = readMeta(directory, tenant);
@@ -55,62 +36,14 @@ export function selectQuery(
         break;
       }
 
-      if (documentMatches(document, match)) {
+      if (
+        opts.where === "" ||
+        evaluateCondition(parseCondition(opts.where, document))
+      ) {
         const doc = opts.expandKeys
           ? recursivelyExpandDocument(directory, tenant, document)
           : document;
 
-        if (opts.showKeys) {
-          results.push({
-            ...doc,
-            ...{
-              key,
-            },
-          });
-        } else {
-          results.push(doc);
-        }
-      }
-    }
-  }
-
-  return results;
-}
-
-export function selectQueries(
-  directory: string,
-  tenant: string,
-  table: string,
-  matches: Match[],
-  statement: string,
-  opts: QueryOptions,
-) {
-  const meta = readMeta(directory, tenant);
-
-  if (!Object.hasOwn(meta.table_index, table)) {
-    throw `No table with name "${table}" to select from`;
-  }
-
-  const results: Document[] = [];
-
-  for (const chunkName of meta.table_index[table].chunks) {
-    const chunk = readChunk(directory, tenant, chunkName);
-    for (const key of Object.keys(chunk)) {
-      const document = chunk[key];
-      if (opts.maxResults === results.length) {
-        break;
-      }
-
-      const curMatches: boolean[] = matches.map((match) =>
-        documentMatches(document, match)
-      );
-
-      const parseTree = parseCondition(statement, curMatches);
-
-      if (evaluateCondition(parseTree)) {
-        const doc = opts.expandKeys
-          ? recursivelyExpandDocument(directory, tenant, document)
-          : document;
         if (opts.showKeys) {
           results.push({
             ...doc,

--- a/src/util/condition_test.ts
+++ b/src/util/condition_test.ts
@@ -3,7 +3,7 @@ import { assert } from "../../deps.ts";
 import { evaluateCondition, parseCondition } from "./condition.ts";
 
 const evaluate = (condition: string) => {
-  return evaluateCondition(parseCondition(condition, ""));
+  return evaluateCondition(parseCondition(condition, {}));
 };
 
 Deno.test("Examples in README work", () => {


### PR DESCRIPTION
Closes #32. We should land the other query-related things and make a `0.2.0` release. We then would need to update the deno driver.