### PR TITLE
breaking: feat: remove show_key option

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -104,7 +104,6 @@ export function start(directory: string) {
             table,
             {
               maxResults: body.max_results ?? 100,
-              showKeys: body.show_keys ?? true,
               expandKeys: body.expand_keys ?? false,
               where: body.where ?? "",
               alias: body.alias,

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -121,6 +121,8 @@ Deno.test({
   sanitizeOps: false,
 });
 
+let yogiKeys: string[] = [];
+
 Deno.test({
   name: "Able to bulk insert into a table",
   async fn() {
@@ -155,7 +157,7 @@ Deno.test({
     });
 
     assertEquals(req.status, 200);
-    await req.text();
+    yogiKeys = await req.json();
   },
   sanitizeResources: false,
   sanitizeOps: false,
@@ -327,6 +329,7 @@ Deno.test({
       age: 12,
       cool: true,
       description: "The best avenger",
+      key: yogiKey,
     });
 
     req = await fetch(
@@ -343,6 +346,7 @@ Deno.test({
       height: null,
       best_friend: bryanKey,
       nested: { property: "coder", another_level: { property: "coder again" } },
+      key: olekKey,
     });
 
     req = await fetch(`http://localhost:8777/get/tableWithSchema/${olekKey}`, {
@@ -371,8 +375,10 @@ Deno.test({
           property: "builder",
           another_level: { property: "builder again" },
         },
+        key: bryanKey,
       },
       nested: { property: "coder", another_level: { property: "coder again" } },
+      key: olekKey,
     });
   },
   sanitizeResources: false,
@@ -434,39 +440,65 @@ Deno.test({
   async fn() {
     let req = await fetch(`http://localhost:8777/select/table`, {
       ...basicFetchOptions,
-      body: JSON.stringify({
-        show_keys: false,
-      }),
     });
 
     assertEquals(await req.json(), [
-      { name: "Yogi", age: 13, cool: true, description: "The best avenger" },
-      { name: "Yogi1", age: 13, cool: true, description: "The best avenger" },
-      { name: "Yogi2", age: 14, cool: true, description: "The best avenger" },
-      { name: "Yogi3", age: 15, cool: true, description: "The best avenger" },
-      { name: "Yogi4", age: 16, cool: true, description: "The best avenger" },
+      {
+        name: "Yogi",
+        age: 13,
+        cool: true,
+        description: "The best avenger",
+        key: yogiKey,
+      },
+      {
+        name: "Yogi1",
+        age: 13,
+        cool: true,
+        description: "The best avenger",
+        key: yogiKeys[0],
+      },
+      {
+        name: "Yogi2",
+        age: 14,
+        cool: true,
+        description: "The best avenger",
+        key: yogiKeys[1],
+      },
+      {
+        name: "Yogi3",
+        age: 15,
+        cool: true,
+        description: "The best avenger",
+        key: yogiKeys[2],
+      },
+      {
+        name: "Yogi4",
+        age: 16,
+        cool: true,
+        description: "The best avenger",
+        key: yogiKeys[3],
+      },
     ]);
 
     req = await fetch(`http://localhost:8777/select/table`, {
       ...basicFetchOptions,
       body: JSON.stringify({
         where: "eq($name, 'Yogi')",
-        show_keys: false,
       }),
     });
 
     assertEquals(await req.json(), [{
-      "name": "Yogi",
-      "age": 13,
-      "cool": true,
-      "description": "The best avenger",
+      name: "Yogi",
+      age: 13,
+      cool: true,
+      description: "The best avenger",
+      key: yogiKey,
     }]);
 
     req = await fetch(`http://localhost:8777/select/tableWithSchema`, {
       ...basicFetchOptions,
       body: JSON.stringify({
         where: "gt($age, 10)",
-        show_keys: false,
       }),
     });
 
@@ -483,6 +515,7 @@ Deno.test({
           property: "builder",
           another_level: { property: "builder again" },
         },
+        key: bryanKey,
       },
       {
         name: "Olek",
@@ -496,6 +529,7 @@ Deno.test({
           property: "coder",
           another_level: { property: "coder again" },
         },
+        key: olekKey,
       },
     ];
 
@@ -505,7 +539,6 @@ Deno.test({
       ...basicFetchOptions,
       body: JSON.stringify({
         where: "or(eq($age, 18), eq($nested.property, 'coder'))",
-        show_keys: false,
       }),
     });
 
@@ -515,7 +548,6 @@ Deno.test({
       ...basicFetchOptions,
       body: JSON.stringify({
         where: "or(eq($age, 18), eq($nested.property, 'coder'))",
-        show_keys: true,
         expand_keys: true,
       }),
     });
@@ -566,7 +598,6 @@ Deno.test({
       body: JSON.stringify({
         where: "or(eq($age, 18), eq($nested.property, 'coder'))",
         max_results: 1,
-        show_keys: false,
       }),
     });
 
@@ -588,14 +619,14 @@ Deno.test({
           ageDoubled: "multiply($age, 2)",
           notCool: "not($cool)",
         },
-        show_keys: false,
       }),
     });
 
     assertEquals(await req.json(), [{
-      "name": "Yogi",
-      "ageDoubled": 26,
-      "notCool": false,
+      name: "Yogi",
+      ageDoubled: 26,
+      notCool: false,
+      key: yogiKey,
     }]);
   },
   sanitizeResources: false,
@@ -611,7 +642,6 @@ Deno.test({
         order: {
           by: "$age",
         },
-        show_keys: false,
         max_results: 1,
       }),
     });
@@ -621,6 +651,7 @@ Deno.test({
       age: 16,
       cool: true,
       description: "The best avenger",
+      key: yogiKeys[3],
     }]);
 
     req = await fetch(`http://localhost:8777/select/table`, {
@@ -630,7 +661,6 @@ Deno.test({
           descending: true,
           by: "$age",
         },
-        show_keys: false,
         max_results: 1,
       }),
     });
@@ -640,6 +670,7 @@ Deno.test({
       age: 13,
       cool: true,
       description: "The best avenger",
+      key: yogiKey,
     }]);
   },
   sanitizeResources: false,

--- a/src/operations/get.ts
+++ b/src/operations/get.ts
@@ -28,12 +28,18 @@ export function get(
 
   const chunk = readChunk(directory, tenant, chunkName);
 
+  let document = chunk[key];
+
   if (opts.expandKeys) {
-    return recursivelyExpandDocument(
+    document = recursivelyExpandDocument(
       directory,
       tenant,
-      chunk[key],
+      document,
     );
   }
-  return chunk[key];
+
+  return {
+    ...document,
+    key,
+  };
 }

--- a/src/operations/select.ts
+++ b/src/operations/select.ts
@@ -8,7 +8,6 @@ import { Alias, Document } from "../util/types.ts";
 
 interface QueryOptions {
   maxResults: number;
-  showKeys: boolean;
   expandKeys: boolean;
   where: string;
   alias?: Alias;
@@ -54,7 +53,6 @@ export function select(
             directory,
             tenant,
             doc,
-            opts.showKeys,
           ); // expand keys of document before alias
         }
         if (opts.alias) doc = recursivelyExpandAlias(opts.alias, doc);
@@ -63,10 +61,9 @@ export function select(
             directory,
             tenant,
             doc,
-            opts.showKeys,
           ); // expand keys of alias
         }
-        if (opts.showKeys) doc = { ...doc, key };
+        doc = { ...doc, key };
 
         results.push(doc);
       }

--- a/src/util/expandDocument.ts
+++ b/src/util/expandDocument.ts
@@ -10,7 +10,6 @@ export function recursivelyExpandDocument(
   directory: string,
   tenant: string,
   document: Document,
-  showKeys?: boolean,
 ) {
   const metaTable = readMeta(directory, tenant);
 
@@ -25,18 +24,15 @@ export function recursivelyExpandDocument(
 
         let subdocument = chunk[value];
 
-        if (showKeys) {
-          subdocument = {
-            ...subdocument,
-            key: value,
-          };
-        }
+        subdocument = {
+          ...subdocument,
+          key: value,
+        };
 
         document[key] = recursivelyExpandDocument(
           directory,
           tenant,
           subdocument,
-          showKeys,
         );
       }
     } else if (typeof value === "object" && value !== null) {
@@ -44,7 +40,6 @@ export function recursivelyExpandDocument(
         directory,
         tenant,
         document[key] as Document,
-        showKeys,
       );
     }
   }


### PR DESCRIPTION
I realize that there really is never a moment where it's negative to add keys (even in simple `/get` requests). I have decided to remove this option entirely. 

Maybe history will show that I was wrong but /shrug